### PR TITLE
Many updates across the site

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,10 +38,10 @@
       </center>
 
         <h2>What's going on?</h2>
-        <p>Linux is borrowing unused memory for disk caching. This makes it look like you are low on "free" memory, but you are not! Everything is fine!</p>
+        <p>Like all modern operating systems, Linux is borrowing unused memory for disk caching. This makes it look like you are low on "free" memory, but you are not! Everything is fine!</p>
 
         <h2>Why is it doing this?</h2>
-        <p>Disk caching makes the system much faster and more responsive! There are no downsides, except for confusing newbies. It does not take memory away from applications in any way, ever!</p>
+        <p>Disk caching makes the system much faster and more responsive! There are no downsides, except for confusing users who are new to computing, and unfamiliar with the concept of a filesystem cache. It does not take memory away from applications in any way, ever!</p>
 
         <h2>What if I want to run more applications?</h2>
         <p>If your applications want more memory, they just take back a chunk that the disk cache borrowed. Disk cache can always be given back to applications immediately! You are not low on ram!</p>

--- a/index.html
+++ b/index.html
@@ -41,13 +41,13 @@
         <p>Like all modern operating systems, Linux is borrowing unused memory for disk caching. This makes it look like you are low on "free" memory, but you are not! Everything is fine!</p>
 
         <h2>Why is it doing this?</h2>
-        <p>Disk caching makes the system much faster and more responsive! There are no downsides, except for confusing users who are new to computing, and unfamiliar with the concept of a filesystem cache. It does not take memory away from applications in any way, ever!</p>
+        <p>Disk caching makes the system much faster and more responsive! There are no downsides, except for confusing users who are new to computing, and unfamiliar with the concept of a filesystem cache. It doesn't generally take memory away from applications.</p>
 
         <h2>What if I want to run more applications?</h2>
         <p>If your applications want more memory, the kernel will just take back a chunk that the disk cache borrowed. Disk cache can always be given back to applications immediately! You are not low on ram!</p>
 
         <h2>Do I need more swap?</h2>
-        <p>No, disk caching only borrows the ram that applications don't currently want. It will not use swap. If applications want more memory, they just take it back from the disk cache. They will not start swapping.</p>
+        <p>Probably not; disk caching primarily borrows the ram that applications don't currently want. If applications want more memory, the kernel will take it back from the disk cache. Linux <em>can</em> push application memory into swap if that memory is accessed less often than the filesystem cache, but this will typically improve performance, not hurt it.</p>
 
         <h2>How do I stop Linux from doing this?</h2>
         <p>You can't disable disk caching. The only reason anyone ever wants to disable disk caching is because they think it takes memory away from their applications, which it doesn't! Disk cache makes applications load faster and run smoother, but it NEVER EVER takes memory away from them! Therefore, there's absolutely no reason to disable it!</p>

--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
         <pre>
   $ free -m
                 total        used        free      shared  buff/cache   available
-  Mem:           1504        1491          13           0         855      <span style="border: 1px solid"><strong>792</strong></span>
+  Mem:           1504         636          13           0         855      <span style="border: 1px solid"><strong>792</strong></span>
   Swap:          2047           6        2041
 </pre>
         <p><small>(On installations from before 2016, look at "free" column in the "-/+ buffers/cache" row instead.)</small></p>

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
             <tr>
               <td bgcolor="#FFFF80">used, but can be made available</td>
               <td bgcolor="#80FF80">Free (or Available)</td>
-              <td bgcolor="#FF8080">Used (and Available)</td>
+              <td bgcolor="#80FF80">Available</td>
             </tr>
             <tr>
               <td bgcolor="#80FF80">not used for anything</td>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
         <p>Disk caching makes the system much faster and more responsive! There are no downsides, except for confusing users who are new to computing, and unfamiliar with the concept of a filesystem cache. It does not take memory away from applications in any way, ever!</p>
 
         <h2>What if I want to run more applications?</h2>
-        <p>If your applications want more memory, they just take back a chunk that the disk cache borrowed. Disk cache can always be given back to applications immediately! You are not low on ram!</p>
+        <p>If your applications want more memory, the kernel will just take back a chunk that the disk cache borrowed. Disk cache can always be given back to applications immediately! You are not low on ram!</p>
 
         <h2>Do I need more swap?</h2>
         <p>No, disk caching only borrows the ram that applications don't currently want. It will not use swap. If applications want more memory, they just take it back from the disk cache. They will not start swapping.</p>

--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
   Swap:          2047           6        2041
 </pre>
         <p><small>(On installations from before 2014, look at "free" column in the "-/+ buffers/cache" row instead.)</small></p>
-        <p>This is your answer in MiB. If you just naively look at "used" and "free", you'll think your ram is 99% full when it's really just 47%!</p>
+        <p>This is your answer in MiB. If you just naively look at "free", you'll think your ram is 99% full when it's really just 42%!</p>
         <p>For a more detailed and technical description of what Linux counts as "available", see <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773">the commit that added the field</a>.</p>
 
         <h2>When should I start to worry?</h2>

--- a/index.html
+++ b/index.html
@@ -53,10 +53,10 @@
         <p>You can't completely disable disk caching, (but you can tune Linux's "swapiness"). The only reason anyone ever wants to disable disk caching is because they think it takes memory away from their applications, which it doesn't! Disk cache makes applications load faster and run smoother, but it NEVER EVER takes memory away from them! Therefore, there's absolutely no reason to disable it!</p>
         <p>If, however, you find yourself needing to clear some RAM quickly for some reason, like benchmarking the cold-start of an uncached application, you can force linux to nondestructively <a href="https://linux-mm.org/Drop_Caches">drop caches</a> using <code>echo 3 | sudo tee /proc/sys/vm/drop_caches</code>.</p>
 
-        <h2>Why does top and free say all my ram is used if it isn't?</h2>
+        <h2>Why do top and free say that so little ram is free if it is?</h2>
         <p>This is just a difference in terminology. Both you and Linux agree that memory taken by applications is "used", while memory that isn't used for anything is "free".</p>
         <p>But how do you count memory that is currently used for something, but can still be made available to applications?</p>
-        <p>You might count that memory as "free" and/or "available". Linux instead counts it as "used", but also "available":</p>
+        <p>You might count that memory as "free" and/or "available". Linux instead counts it as "available":</p>
         <table>
           <thead>
             <tr>

--- a/index.html
+++ b/index.html
@@ -101,7 +101,6 @@
         <p>A <strong>healthy Linux system</strong> with more than enough memory will, after running for a while, show the following expected and harmless behavior:</p>
         <ul>
           <li><code>free</code> memory is close to <code>0</code> </li>
-          <li><code>used</code> memory is close to <code>total</code> </li>
           <li><code>available</code> memory (or "free + buffers/cache") has enough room (let's say, 20%+ of total)</li>
           <li><code>swap used</code> does not change</li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
   Mem:           1504         636          13           0         855      <span style="border: 1px solid"><strong>792</strong></span>
   Swap:          2047           6        2041
 </pre>
-        <p><small>(On installations from before 2016, look at "free" column in the "-/+ buffers/cache" row instead.)</small></p>
+        <p><small>(On installations from before 2014, look at "free" column in the "-/+ buffers/cache" row instead.)</small></p>
         <p>This is your answer in MiB. If you just naively look at "used" and "free", you'll think your ram is 99% full when it's really just 47%!</p>
         <p>For a more detailed and technical description of what Linux counts as "available", see <a href="https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773">the commit that added the field</a>.</p>
 

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
       </center>
 
         <h2>What's going on?</h2>
-        <p>Linux is borrowing unused memory for disk caching. This makes it look like you are low on memory, but you are not! Everything is fine!</p>
+        <p>Linux is borrowing unused memory for disk caching. This makes it look like you are low on "free" memory, but you are not! Everything is fine!</p>
 
         <h2>Why is it doing this?</h2>
         <p>Disk caching makes the system much faster and more responsive! There are no downsides, except for confusing newbies. It does not take memory away from applications in any way, ever!</p>

--- a/index.html
+++ b/index.html
@@ -50,8 +50,8 @@
         <p>Probably not; disk caching primarily borrows the ram that applications don't currently want. If applications want more memory, the kernel will take it back from the disk cache. Linux <em>can</em> push application memory into swap if that memory is accessed less often than the filesystem cache, but this will typically improve performance, not hurt it.</p>
 
         <h2>How do I stop Linux from doing this?</h2>
-        <p>You can't disable disk caching. The only reason anyone ever wants to disable disk caching is because they think it takes memory away from their applications, which it doesn't! Disk cache makes applications load faster and run smoother, but it NEVER EVER takes memory away from them! Therefore, there's absolutely no reason to disable it!</p>
-        <p>If, however, you find yourself needing to clear some RAM quickly to workaround another issue, like a VM misbehaving, you can force linux to nondestructively <a href="https://linux-mm.org/Drop_Caches">drop caches</a> using <code>echo 3 | sudo tee /proc/sys/vm/drop_caches</code>.</p>
+        <p>You can't completely disable disk caching, (but you can tune Linux's "swapiness"). The only reason anyone ever wants to disable disk caching is because they think it takes memory away from their applications, which it doesn't! Disk cache makes applications load faster and run smoother, but it NEVER EVER takes memory away from them! Therefore, there's absolutely no reason to disable it!</p>
+        <p>If, however, you find yourself needing to clear some RAM quickly for some reason, like benchmarking the cold-start of an uncached application, you can force linux to nondestructively <a href="https://linux-mm.org/Drop_Caches">drop caches</a> using <code>echo 3 | sudo tee /proc/sys/vm/drop_caches</code>.</p>
 
         <h2>Why does top and free say all my ram is used if it isn't?</h2>
         <p>This is just a difference in terminology. Both you and Linux agree that memory taken by applications is "used", while memory that isn't used for anything is "free".</p>

--- a/play.html
+++ b/play.html
@@ -56,10 +56,9 @@ $ <b>free -m</b>
 </pre>
       <p><i>(note that your <code>free</code> output could be different, and have an 'available' column instead of a '-/+' row)</i></p>
       <pre>
-             total       used       free     shared    buffers     cached
-Mem:          1504       1490         14          0         24        809
--/+ buffers/cache:        656        848
-Swap:            0          0          0
+              total        used        free      shared  buff/cache   available
+Mem:           1504         636          13           0         855      792
+Swap:             0           0           0
 
 $ <b>gcc munch.c -o munch</b>
 
@@ -73,10 +72,9 @@ Allocated 879 MB
 Killed
 
 $ <b>free -m</b>
-             total       used       free     shared    buffers     cached
-Mem:          1504        650        854          0          1         67
--/+ buffers/cache:        581        923
-Swap:            0          0          0
+              total        used        free      shared  buff/cache   available
+Mem:           1504         581         922           0           1      922
+Swap:             0           0           0
 </pre>
 
       <p>Even though it said 14MB "free", that didn't stop the application from grabbing 879MB. Afterwards, the cache is pretty empty<sup><a href="#footnote2">2</a></sup>, but it will gradually fill up again as files are read and written. Give it a try. </p>
@@ -86,10 +84,9 @@ Swap:            0          0          0
 
       <pre>
 $ <b>free -m</b>
-             total       used       free     shared    buffers     cached
-Mem:          1504       1490         14          0         10        874
--/+ buffers/cache:        605        899
-Swap:         2047          6       2041
+              total        used        free      shared  buff/cache   available
+Mem:           1504         636          13           0         855      792
+Swap:          2047           6        2041
 
 $ <b>./munch 400</b>
 Allocated 1 MB
@@ -99,10 +96,9 @@ Allocated 399 MB
 Allocated 400 MB
 
 $ <b>free -m</b>
-             total       used       free     shared    buffers     cached
-Mem:          1504       1090        414          0          5        485
--/+ buffers/cache:        598        906
-Swap:         2047          6       2041
+              total        used        free      shared  buff/cache   available
+Mem:           1504         636         413           0         455      792
+Swap:          2047           6        2041
 </pre>
 
       <p><code>munch</code> ate 400MB of ram, which was taken from the disk cache without resorting to swap. Likewise, we can fill the disk cache again and it will not start eating swap either. If you run <code>watch free -m</code> in one terminal, and <code>find . -type f -exec cat {} + > /dev/null</code> in another, you can see that "cached" will rise while "free" falls. After a while, it tapers off but swap is never touched<sup><a href="#footnote1">1</a></sup>.</p>
@@ -112,19 +108,17 @@ Swap:         2047          6       2041
 
       <pre>
 $ <b>free -m</b>
-             total       used       free     shared    buffers     cached
-Mem:          1504       1471         33          0         36        801
--/+ buffers/cache:        633        871
-Swap:         2047          6       2041
+              total        used        free      shared  buff/cache   available
+Mem:           1504         636          13           0         855      792
+Swap:          2047           6        2041
 
 $ <b>echo 3 | sudo tee /proc/sys/vm/drop_caches </b>
 3
 
 $ <b>free -m</b>
-             total       used       free     shared    buffers     cached
-Mem:          1504        763        741          0          0        134
--/+ buffers/cache:        629        875
-Swap:         2047          6       2041
+              total        used        free      shared  buff/cache   available
+Mem:           1504         636         734           0         134      792
+Swap:          2047           6        2041
 </pre>
       <p>Notice how "buffers" and "cached" went down, free mem went up, and free+buffers/cache stayed the same.</p>
 
@@ -204,10 +198,9 @@ $ <b>echo 3 | sudo tee /proc/sys/vm/drop_caches</b>
 3
 
 $ <b>free -m</b>
-             total       used       free     shared    buffers     cached
-Mem:          1504        546        958          0          0         85
--/+ buffers/cache:        461       1043
-Swap:         2047          6       2041
+              total        used        free      shared  buff/cache   available
+Mem:           1504         465         954           0          85      960
+Swap:          2047           6        2041
 
 $ <b>dd if=/dev/zero of=bigfile bs=1M count=200</b>
 200+0 records in
@@ -218,10 +211,9 @@ $ <b>ls -lh bigfile</b>
 -rw-r--r-- 1 vidar vidar 200M 2009-04-25 12:30 bigfile
 
 $ <b>free -m</b>
-             total       used       free     shared    buffers     cached
-Mem:          1504        753        750          0          0        285
--/+ buffers/cache:        468       1036
-Swap:         2047          6       2041
+              total        used        free      shared  buff/cache   available
+Mem:           1504         465         754           0          285      960
+Swap:          2047           6        2041
 </pre>
 
       <p>Since the file was just written, it will go in the disk cache. The 200MB file caused a 200MB bump in "cached". Let's read it, clear the cache, and read it again to see how fast it is:</p>


### PR DESCRIPTION
linuxatemyram was created to explain a bad UX that hasn't existed in almost 10 years.  It was partially updated to reflect the change in the output from the `free` command in 2014, but that update was inaccurate.  `free` hasn't included cache memory in the "used" column since the change in 2014.  Correcting for that change necessitates a fairly substantial number of changes across the site.